### PR TITLE
fix: define UnityEditor namespace for clarity

### DIFF
--- a/client/Assets/Automation/Engine/Xtra/Editor/Swat/Utilities/Swat.cs
+++ b/client/Assets/Automation/Engine/Xtra/Editor/Swat/Utilities/Swat.cs
@@ -272,7 +272,7 @@ namespace TrilleonAutomation {
 
 			GetWindow(type, false, name).Close(); 
 
-			Assembly editorAssembly = typeof(Editor).Assembly;
+			Assembly editorAssembly = typeof(UnityEditor.Editor).Assembly;
 			Type dockWindow = null;
 			DockNextTo dockThis;
 


### PR DESCRIPTION
Was getting a compiler error when integrating into one of my projects, this was the culprit.